### PR TITLE
Add event category parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ let fdkClient = setupFdk({
         handler: handleExtUninstall
       },
       'coupon/create': {
+        event_category: "application", // optional. Required if handling event name is for company and sales channel. Refer examples/test.js
         handler: handleCouponCreate
       }
     }

--- a/README.md
+++ b/README.md
@@ -107,12 +107,15 @@ let fdkClient = setupFdk({
     subscribed_saleschannel: 'specific', //optional. Default all
     event_map: { // required
       'brand/create': {
+        version: '1',
         handler: handleBrandCreate
       },
       'location/update': {
+        version: '1',
         handler: handleLocationUpdate
       },
       'application/coupon/create': {
+        version: '1',
         handler: handleCouponCreate
       }
     }

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ let fdkClient = setupFdk({
     subscribe_on_install: false, //optional. Default true
     subscribed_saleschannel 'specific', //optional. Default all
     event_map: { // required
-      'extension/install': {
-        handler: handleExtInstall
+      'brand/create': {
+        handler: handleBrandCreate
       },
-      'extension/uninstall': {
-        handler: handleExtUninstall
+      'location/update': {
+        handler: handleLocationUpdate
       },
       'coupon/create': {
         event_category: "application", // optional. Required if handling event name is for company and sales channel. Refer examples/test.js

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let fdkClient = setupFdk({
     api_path: "/api/v1/webhooks", // required
     notification_email: "test@abc.com", // required
     subscribe_on_install: false, //optional. Default true
-    subscribed_saleschannel 'specific', //optional. Default all
+    subscribed_saleschannel: 'specific', //optional. Default all
     event_map: { // required
       'brand/create': {
         handler: handleBrandCreate
@@ -112,8 +112,7 @@ let fdkClient = setupFdk({
       'location/update': {
         handler: handleLocationUpdate
       },
-      'coupon/create': {
-        event_category: "application", // optional. Required if handling event name is for company and sales channel. Refer examples/test.js
+      'application/coupon/create': {
         handler: handleCouponCreate
       }
     }
@@ -130,7 +129,7 @@ There should be view on given api path to receive webhook call. It should be `PO
 
 ```javascript
 
-app.post('/api/v1/webhooks', async (req, res, next) {
+app.post('/api/v1/webhooks', async (req, res, next) => {
   try {
     await fdkClient.webhookRegistry.processWebhook(req);
     return res.status(200).json({"success": true});

--- a/examples/test.js
+++ b/examples/test.js
@@ -37,6 +37,11 @@ function handleSalesChannelProductEvent(payload, companyId, applicationId) {
     console.log(payload);
 }
 
+function handleLocationEvent(payload, companyId) {
+    console.log(`Event received for ${companyId} and event_category ${payload.event.category}`);
+    console.log(payload);
+}
+
 
 const redis = new Redis();
 
@@ -56,6 +61,9 @@ let fdkExtension = setupFdk({
         event_map: { // required
             'application/coupon/update': {
                 handler: handleCouponEdit
+            },
+            'location/update': {
+                handler: handleLocationEvent
             },
             'product/create': {
                 handler: handleProductEvent

--- a/examples/test.js
+++ b/examples/test.js
@@ -62,10 +62,10 @@ let fdkExtension = setupFdk({
             'application/coupon/update': {
                 handler: handleCouponEdit
             },
-            'location/update': {
+            'company/location/update': {
                 handler: handleLocationEvent
             },
-            'product/create': {
+            'company/product/create': {
                 handler: handleProductEvent
             },
             'application/product/create': {

--- a/examples/test.js
+++ b/examples/test.js
@@ -21,10 +21,6 @@ let data = fs.readFileSync(path.join(__dirname + "/.ngrock"));
 let baseUrl = data.toString() || "http://localhost:5070";
 console.log(baseUrl);
 
-function handleExtInstall(payload, companyId) {
-    console.log(`Event received for ${companyId}`);
-    console.log(payload);
-}
 
 function handleCouponEdit(payload, companyId, applicationId) {
     console.log(`Event received for ${companyId} and ${applicationId}`);
@@ -58,18 +54,14 @@ let fdkExtension = setupFdk({
         notification_email: "test2@abc.com", // required
         subscribed_saleschannel: 'specific', //optional
         event_map: { // required
-            'extension/install': {
-                handler: handleExtInstall
-            },
-            'coupon/update': {
+            'application/coupon/update': {
                 handler: handleCouponEdit
             },
             'product/create': {
-                handler: handleCouponEdit
+                handler: handleProductEvent
             },
-            'product/create': {
-                event_category: 'application', // optional unless multiple event with same name are present at company and saleschannel
-                handler: handleCouponEdit
+            'application/product/create': {
+                handler: handleSalesChannelProductEvent
             }
         }
     }

--- a/examples/test.js
+++ b/examples/test.js
@@ -60,15 +60,19 @@ let fdkExtension = setupFdk({
         subscribed_saleschannel: 'specific', //optional
         event_map: { // required
             'application/coupon/update': {
+                version: '1',
                 handler: handleCouponEdit
             },
             'company/location/update': {
+                version: '1',
                 handler: handleLocationEvent
             },
             'company/product/create': {
+                version: '1',
                 handler: handleProductEvent
             },
             'application/product/create': {
+                version: '1',
                 handler: handleSalesChannelProductEvent
             }
         }

--- a/express/constants.js
+++ b/express/constants.js
@@ -4,5 +4,6 @@ exports.SESSION_COOKIE_NAME = "ext_session";
 exports.TEST_WEBHOOK_EVENT_NAME = "ping"
 exports.ASSOCIATION_CRITERIA = {
     ALL: "ALL",
-    SPECIFIC: "SPECIFIC-EVENTS"
+    SPECIFIC: "SPECIFIC-EVENTS", // to be set when saleschannel specific events are subscribed and sales channel present
+    EMPTY: "EMPTY" // to be set when saleschannel specific events are subscribed but not sales channel present
 }

--- a/express/routes.js
+++ b/express/routes.js
@@ -131,7 +131,7 @@ function setupRoutes(ext) {
             req.extension = ext;
             if(ext.webhookRegistry.isInitialized()) {
                 const client = await ext.getPlatformClient(req.fdkSession.company_id, req.fdkSession);
-                await ext.webhookRegistry.syncEvents(client);
+                await ext.webhookRegistry.syncEvents(client, null, true);
             }
             let redirectUrl = await ext.callbacks.auth(req);
             logger.debug(`Redirecting after auth callback to url: ${redirectUrl}`);
@@ -154,6 +154,10 @@ function setupRoutes(ext) {
                 req.platformClient = client;
             }
             req.extension = ext;
+            if(ext.webhookRegistry.isInitialized()) {
+                // mark webhook subscriber inactive if uninstalled
+                await ext.webhookRegistry.syncEvents(platformClient, null, false);
+            }
             await ext.callbacks.uninstall(req);
             res.json({success: true});
         } catch (error) {

--- a/express/routes.js
+++ b/express/routes.js
@@ -154,10 +154,6 @@ function setupRoutes(ext) {
                 req.platformClient = client;
             }
             req.extension = ext;
-            if(ext.webhookRegistry.isInitialized()) {
-                // mark webhook subscriber inactive if uninstalled
-                await ext.webhookRegistry.syncEvents(platformClient, null, false);
-            }
             await ext.callbacks.uninstall(req);
             res.json({success: true});
         } catch (error) {

--- a/express/webhook.js
+++ b/express/webhook.js
@@ -39,11 +39,7 @@ class WebhookRegistry {
 
     _getEventIdMap(events) {
         return events.reduce((event_map, event) => {
-            if (event.event_category && event.event_category === "application") {
-                event_map[`${event.event_category}/${event.event_name}/${event.event_type}`] = event.id;
-            } else {
-                event_map[`${event.event_name}/${event.event_type}`] = event.id;
-            }
+            event_map[`${event.event_category}/${event.event_name}/${event.event_type}`] = event.id;
             return event_map;
         }, {});
     }

--- a/express/webhook.js
+++ b/express/webhook.js
@@ -183,6 +183,9 @@ class WebhookRegistry {
         try {
             let subscriberConfig = await platformClient.webhook.getSubscribersByExtensionId({ extensionId: this._fdkConfig.api_key })
             subscriberConfig = subscriberConfig.items[0];
+            if (!subscriberConfig) {
+                throw new FdkWebhookRegistrationError(`Subscriber config not found`);
+            }
             const { id, name, webhook_url, association, status, auth_meta, email_id, event_configs } = subscriberConfig;
             subscriberConfig = { id, name, webhook_url, association, status, auth_meta, email_id };
             subscriberConfig.event_id = event_configs.map(event => event.id);
@@ -207,6 +210,9 @@ class WebhookRegistry {
         try {
             let subscriberConfig = await platformClient.webhook.getSubscribersByExtensionId({ extensionId: this._fdkConfig.api_key })
             subscriberConfig = subscriberConfig.items[0];
+            if (!subscriberConfig) {
+                throw new FdkWebhookRegistrationError(`Subscriber config not found`);
+            }
             const { id, name, webhook_url, association, status, auth_meta, email_id, event_configs } = subscriberConfig;
             subscriberConfig = { id, name, webhook_url, association, status, auth_meta, email_id };
             subscriberConfig.event_id = event_configs.map(event => event.id);

--- a/express/webhook.js
+++ b/express/webhook.js
@@ -28,11 +28,7 @@ class WebhookRegistry {
         this._config = config;
         this._fdkConfig = fdkConfig;
         for (let [eventName, handlerData] of Object.entries(this._config.event_map)) {
-            let categoryEventName = eventName;
-            if(handlerData.category) {
-                categoryEventName = `${handlerData.category}/${eventName}`;
-            }
-            this._handlerMap[categoryEventName] = handlerData;
+            this._handlerMap[eventName] = handlerData;
         }
         logger.debug('Webhook registry initialized');
     }
@@ -42,12 +38,13 @@ class WebhookRegistry {
     }
 
     _getEventIdMap(events) {
-        return events.reduce((map, event) => {
-            map[`${event.event_name}/${event.event_type}`] = event.id;
-            if (event.event_category) {
-                map[`${event.event_category}/${event.event_name}/${event.event_type}`] = event.id;
+        return events.reduce((event_map, event) => {
+            if (event.event_category && event.event_category === "application") {
+                event_map[`${event.event_category}/${event.event_name}/${event.event_type}`] = event.id;
+            } else {
+                event_map[`${event.event_name}/${event.event_type}`] = event.id;
             }
-            return map;
+            return event_map;
         }, {});
     }
 

--- a/express/webhook.js
+++ b/express/webhook.js
@@ -39,7 +39,7 @@ class WebhookRegistry {
 
     _getEventIdMap(events) {
         return events.reduce((event_map, event) => {
-            event_map[`${event.event_category}/${event.event_name}/${event.event_type}`] = event.id;
+            event_map[`${event.event_category}/${event.event_name}/${event.event_type}/${event.version}`] = event.id;
             return event_map;
         }, {});
     }
@@ -91,7 +91,7 @@ class WebhookRegistry {
         let eventsMap = null;
         const promises = [];
 
-        promises.push(platformClient.webhook.fetchAllEventConfigurations());
+        promises.push(platformClient.webhook.fetchAllEventConfigurations()); // TODO:  replace with validate API
         promises.push(platformClient.webhook.getSubscribersByExtensionId({ extensionId: this._fdkConfig.api_key }));
 
         [eventsMap, subscriberConfig] = await Promise.all(promises);
@@ -139,8 +139,10 @@ class WebhookRegistry {
             }
         }
         for (let eventName of Object.keys(this._handlerMap)) {
-            if (eventsMap[eventName]) {
-                subscriberConfig.event_id.push(eventsMap[eventName]);
+            eventName = `${eventName}/${this._handlerMap[eventName].version}`
+            let event_id = eventsMap[eventName]
+            if (event_id) {
+                subscriberConfig.event_id.push(event_id);
             }
         }
 
@@ -258,7 +260,10 @@ class WebhookRegistry {
             if(body.event.category) {
                 categoryEventName = `${body.event.category}/${eventName}`
             }
-            const extHandler = (this._handlerMap[categoryEventName] || this._handlerMap[eventName] || {}).handler;
+
+            const eventHandlerMap = (this._handlerMap[categoryEventName] || this._handlerMap[eventName] || {});
+            const extHandler = eventHandlerMap.handler;
+
             if (typeof extHandler === 'function') {
                 logger.debug(`Webhook event received for company: ${req.body.company_id}, application: ${req.body.application_id || ''}, event name: ${eventName}`);
                 await extHandler(eventName, req.body, req.body.company_id, req.body.application_id);

--- a/express/webhook.js
+++ b/express/webhook.js
@@ -84,7 +84,7 @@ class WebhookRegistry {
         return updated;
     }
 
-    async syncEvents(platformClient, config = null) {
+    async syncEvents(platformClient, config = null, enableWebhooks) {
         logger.debug('Sync events started');
         if (config) {
             this.initialize(config, this._fdkConfig);
@@ -123,6 +123,9 @@ class WebhookRegistry {
                 "email_id": this._config.notification_email
             }
             registerNew = true;
+            if (enableWebhooks !== undefined) {
+                subscriberConfig.status = enableWebhooks? 'active': 'inactive';
+            }
         }
         else {
             logger.debug(`Webhook config on platform side for company id ${platformClient.config.companyId}: ${JSON.stringify(subscriberConfig)}`)
@@ -130,6 +133,10 @@ class WebhookRegistry {
             subscriberConfig = { id, name, webhook_url, association, status, auth_meta, email_id };
             subscriberConfig.event_id = [];
             existingEvents = event_configs.map(event => event.id);
+            if (enableWebhooks !== undefined) {
+                subscriberConfig.status = enableWebhooks? 'active': 'inactive';
+                configUpdated = true;
+            }
             if (this._isConfigUpdated(subscriberConfig)) {
                 configUpdated = true;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fdk-extension-javascript",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -283,7 +283,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
       "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "dev": true,
       "requires": {
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
@@ -325,9 +324,9 @@
       "dev": true
     },
     "@sideway/address": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
-      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -511,8 +510,7 @@
     "async": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
-      "dev": true
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -760,7 +758,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
       "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -770,7 +767,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -778,14 +774,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
       "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -800,14 +794,12 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-      "dev": true,
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
@@ -904,8 +896,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1102,8 +1093,7 @@
     "enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "dev": true
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -1224,12 +1214,11 @@
     "fast-safe-stringify": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==",
-      "dev": true
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
     },
     "fdk-client-javascript": {
-      "version": "git+ssh://git@github.com/gofynd/fdk-client-javascript.git#82d139159a7e937adf7772a4dca497e843046bcd",
-      "from": "git+ssh://git@github.com/gofynd/fdk-client-javascript.git#fynd",
+      "version": "git+ssh://git@github.com/gofynd/fdk-client-javascript.git#b79cc1c10d382d230c7c13597d675362a35435b6",
+      "from": "git+ssh://git@github.com/gofynd/fdk-client-javascript.git#0.1.8",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",
@@ -1241,8 +1230,7 @@
     "fecha": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
-      "dev": true
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "filter-obj": {
       "version": "1.1.0",
@@ -1289,8 +1277,7 @@
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "dev": true
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
       "version": "1.13.3",
@@ -1516,8 +1503,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ioredis": {
       "version": "4.24.2",
@@ -1563,8 +1549,7 @@
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-blob": {
       "version": "2.1.0",
@@ -1587,8 +1572,7 @@
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1782,14 +1766,14 @@
       "dev": true
     },
     "joi": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
-      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.0",
+        "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -1886,8 +1870,7 @@
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "dev": true
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -1941,7 +1924,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
       "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
-      "dev": true,
       "requires": {
         "colors": "^1.2.1",
         "fast-safe-stringify": "^2.0.4",
@@ -1953,8 +1935,7 @@
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2198,7 +2179,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dev": true,
       "requires": {
         "fn.name": "1.x.x"
       }
@@ -2322,8 +2302,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -2559,8 +2538,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2658,7 +2636,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       }
@@ -2746,8 +2723,7 @@
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "standard-as-callback": {
       "version": "2.1.0",
@@ -2926,8 +2902,7 @@
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "dev": true
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -2980,8 +2955,7 @@
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-      "dev": true
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -3052,8 +3026,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -3116,7 +3089,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
       "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
-      "dev": true,
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.1.0",
@@ -3133,7 +3105,6 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -3143,14 +3114,12 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -3161,7 +3130,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
       "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.3.7",
         "triple-beam": "^1.2.0"
@@ -3170,14 +3138,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3192,7 +3158,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "name": "fdk-extension-javascript",
   "description": "FDK Extension Helper Library",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.js",
   "directories": {
     "example": "examples"

--- a/spec/fixtures/webhook_event_configs.js
+++ b/spec/fixtures/webhook_event_configs.js
@@ -1,28 +1,6 @@
 module.exports = {
     "event_configs": [
         {
-            "id": 18,
-            "event_name": "extension",
-            "event_type": "install",
-            "event_category": "company",
-            "version": "1.0",
-            "display_name": "extension-install",
-            "description": "This event gets triggered when extension is install",
-            "created_on": "2021-07-02T11:37:42.365Z",
-            "updated_on": "2021-07-02T11:37:42.365Z"
-        },
-        {
-            "id": 27,
-            "event_name": "extension",
-            "event_type": "uninstall",
-            "event_category": "company",
-            "version": "1.0",
-            "display_name": "extension-uninstall",
-            "description": "This event gets triggered when extension is un-installed",
-            "created_on": "2021-08-30T16:39:11.018Z",
-            "updated_on": "2021-08-30T16:39:11.018Z"
-        },
-        {
             "id": 5,
             "event_name": "coupon",
             "event_type": "create",

--- a/spec/fixtures/webhook_subscriber.js
+++ b/spec/fixtures/webhook_subscriber.js
@@ -32,23 +32,6 @@ module.exports = {
                 "subscriber_id": 16,
                 "created_on": "2021-08-30T13:28:28.229Z"
             }
-        },
-        {
-            "id": 18,
-            "event_name": "extension",
-            "event_type": "install",
-            "event_category": "company",
-            "version": "1.0",
-            "display_name": "extension-install",
-            "description": "This event gets triggered when extension is install",
-            "created_on": "2021-07-02T11:37:42.365Z",
-            "updated_on": "2021-07-02T11:37:42.365Z",
-            "subscriber_event_mapping": {
-                "id": 68,
-                "event_id": 18,
-                "subscriber_id": 16,
-                "created_on": "2021-08-30T13:28:28.229Z"
-            }
         }
     ]
 }

--- a/spec/tests/webhooks.spec.js
+++ b/spec/tests/webhooks.spec.js
@@ -18,7 +18,7 @@ describe("Webhook Integrations", () => {
             api_path: '/v1/webhooks',
             notification_email: 'test@abc.com',
             event_map: {
-                'product/create': {
+                'company/product/create': {
                     handler: function () { }
                 },
                 'application/coupon/create': {

--- a/spec/tests/webhooks.spec.js
+++ b/spec/tests/webhooks.spec.js
@@ -19,9 +19,11 @@ describe("Webhook Integrations", () => {
             notification_email: 'test@abc.com',
             event_map: {
                 'company/product/create': {
+                    version: '1',
                     handler: function () { }
                 },
                 'application/coupon/create': {
+                    version: '1',
                     handler: function () { throw Error('test error') }
                 }
             }
@@ -100,6 +102,7 @@ describe("Webhook Integrations", () => {
             notification_email: 'test@abc.com',
             event_map: {
                 'application/coupon/create': {
+                    version: '1',
                     handler: function () { }
                 }
             }

--- a/spec/tests/webhooks.spec.js
+++ b/spec/tests/webhooks.spec.js
@@ -18,13 +18,10 @@ describe("Webhook Integrations", () => {
             api_path: '/v1/webhooks',
             notification_email: 'test@abc.com',
             event_map: {
-                'extension/install': {
+                'product/create': {
                     handler: function () { }
                 },
-                'extension/uninstall': {
-                    handler: function () { }
-                },
-                'coupon/create': {
+                'application/coupon/create': {
                     handler: function () { throw Error('test error') }
                 }
             }
@@ -65,7 +62,7 @@ describe("Webhook Integrations", () => {
     });
 
     it("Register webhooks", async () => {
-        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "extension", "type": "install"} };
+        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "product", "type": "create", "category": "company"} };
         const res = await request
             .post(`/v1/webhooks`)
             .set('cookie', `${SESSION_COOKIE_NAME}_1=${cookie}`)
@@ -76,7 +73,7 @@ describe("Webhook Integrations", () => {
     });
 
     it("Invalid webhook path", async () => {
-        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "update"} };
+        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "update", "category": "application"} };
         const res = await request
             .post(`/v1/webhooks`)
             .set('cookie', `${SESSION_COOKIE_NAME}_1=${cookie}`)
@@ -86,7 +83,7 @@ describe("Webhook Integrations", () => {
     });
 
     it("Failed webhook handler execution", async () => {
-        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "create"} };
+        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "create", "category": "application"} };
         const res = await request
             .post(`/v1/webhooks`)
             .set('cookie', `${SESSION_COOKIE_NAME}_1=${cookie}`)
@@ -97,17 +94,17 @@ describe("Webhook Integrations", () => {
     });
 
     it("Sync webhooks: Add new", async () => {
-        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "create"} };
+        const reqBody = { "company_id": 1, "payload": { "test": true }, "event": {"name": "coupon", "type": "create", "category": "application"} };
         const newMap = {
             api_path: '/v1/webhooks',
             notification_email: 'test@abc.com',
             event_map: {
-                'coupon/create': {
+                'application/coupon/create': {
                     handler: function () { }
                 }
             }
         }
-        const handlerFn = spyOn(newMap.event_map['coupon/create'], 'handler');
+        const handlerFn = spyOn(newMap.event_map['application/coupon/create'], 'handler');
         const platformClient = await this.fdk_instance.getPlatformClient('1');
         await this.fdk_instance.webhookRegistry.syncEvents(platformClient, newMap);
         const res = await request


### PR DESCRIPTION
Add support for the event category. There are cases like product event is triggered at the company level and application level both like example `product/update` company level and `product/update` at the application level. 



Old config-sample with product event problem : 

```
webhook_config: {
    api_path: "/webhook",
    notification_email: "test2@abc.com", // required
    subscribed_saleschannel: 'specific', //optional
    event_map: { // required
        'coupon/update': {
            handler: handleCouponEdit
        },
        'location/update': {
            handler: handleLocationEvent
        },
        'product/create': {
            handler: handleProductEvent
        },
        'product/create': {
            handler: handleSalesChannelProductEvent
        }
    }
}
```


Added new category name at the event levelsubscription. 

```
webhook_config: {
    api_path: "/webhook",
    notification_email: "test2@abc.com", // required
    subscribed_saleschannel: 'specific', //optional
    event_map: { // required
        'application/coupon/update': {
            version: '1',
            handler: handleCouponEdit
        },
        'company/location/update': {
            version: '1',
            handler: handleLocationEvent
        },
        'company/product/create': {
            version: '1',
            handler: handleProductEvent
        },
        'application/product/create': {
            version: '1',
            handler: handleSalesChannelProductEvent
        }
    }
}
```


