### PR TITLE
Added partitioned attribute on cookies for allowing cookies to be set when 3rd party cookies are disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.13] - 2024-12-10
+### Changed
+- Added `partitioned` attribute on cookies set for extension sessions for Platform and Partners. This is to ensure extension works fine inside iframe when Chrome rolls our 3rd party cookie blocking. To check impact of this refer [MDN CHIPS documentation](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies).
+
 ## [v0.7.12] - 2024-11-18
 ### Changed
 - Added offline token support for partner clients.

--- a/express/routes.js
+++ b/express/routes.js
@@ -51,7 +51,8 @@ function setupRoutes(ext) {
                 httpOnly: true,
                 expires: session.expires,
                 signed: true,
-                sameSite: "None"
+                sameSite: "None",
+                partitioned: true
             });
 
             let redirectUrl;
@@ -137,7 +138,8 @@ function setupRoutes(ext) {
                 httpOnly: true,
                 expires: sessionExpires,
                 signed: true,
-                sameSite: "None"
+                sameSite: "None",
+                partitioned: true
             });
             res.header['x-company-id'] = companyId;
             req.extension = ext;
@@ -261,7 +263,8 @@ function setupRoutes(ext) {
                 httpOnly: true,
                 expires: session.expires,
                 signed: true,
-                sameSite: "none"
+                sameSite: "none",
+                partitioned: true
             });
 
             session.state = uuidv4();
@@ -344,7 +347,8 @@ function setupRoutes(ext) {
                 httpOnly: true, 
                 expires: sessionExpires,
                 signed: true,
-                sameSite: 'none'
+                sameSite: 'none',
+                partitioned: true
             })
 
             let redirectUrl = urljoin(ext.base_url, '/admin')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gofynd/fdk-extension-javascript",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gofynd/fdk-extension-javascript",
-      "version": "0.7.10",
+      "version": "0.7.13",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gofynd/fdk-extension-javascript",
-  "version": "0.7.13",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gofynd/fdk-extension-javascript",
-      "version": "0.7.13",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "name": "@gofynd/fdk-extension-javascript",
   "description": "FDK Extension Helper Library",
-  "version": "0.7.13",
+  "version": "1.0.0",
   "main": "index.js",
   "directories": {
     "example": "examples"


### PR DESCRIPTION
- By default Incognito window of Chrome browsers does not accept third-party cookies.
- This change allows developers to set the `Partitioned` attribute on cookies, enabling them to work in third-party contexts even in Incognito mode.
- Partitioned cookies are isolated by top-level site, enhancing privacy while maintaining functionality.
- This also accommodates upcoming updates from Chrome regarding third-party cookie deprecation and enhances privacy-preserving features for users across different browsing modes.